### PR TITLE
Creating packages dir should now be unnecessary

### DIFF
--- a/.github/workflows/esp8266.yml
+++ b/.github/workflows/esp8266.yml
@@ -53,7 +53,6 @@ jobs:
       # dynamically by the build matrix.
       - name: Install platform
         run: |
-          mkdir -p /home/runner/.arduino15/packages
           arduino-cli core update-index
           arduino-cli core install ${{ matrix.arduino-platform }}
 


### PR DESCRIPTION
See: https://github.com/arduino/actions/issues/10